### PR TITLE
Bug/crash when reading dont exist

### DIFF
--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Sources/Evangelium/Helpers/DateManager.swift
+++ b/Sources/Evangelium/Helpers/DateManager.swift
@@ -39,3 +39,14 @@ extension DateManager {
         }
     }
 }
+
+// Construct a date from an yyyy-MM-dd Strings
+extension Date {
+    init(_ dateString:String) {
+        let dateStringFormatter = DateFormatter()
+        dateStringFormatter.dateFormat = "yyyy-MM-dd"
+        dateStringFormatter.locale = NSLocale(localeIdentifier: "en_US_POSIX") as Locale
+        let date = dateStringFormatter.date(from: dateString)!
+        self.init(timeInterval:0, since:date)
+    }
+}

--- a/Sources/Evangelium/Helpers/DateManager.swift
+++ b/Sources/Evangelium/Helpers/DateManager.swift
@@ -42,11 +42,11 @@ extension DateManager {
 
 // Construct a date from an yyyy-MM-dd Strings
 extension Date {
-    init(_ dateString:String) {
+    init(_ dateString: String) {
         let dateStringFormatter = DateFormatter()
         dateStringFormatter.dateFormat = "yyyy-MM-dd"
-        dateStringFormatter.locale = NSLocale(localeIdentifier: "en_US_POSIX") as Locale
+        dateStringFormatter.locale = Locale(identifier: "en_US_POSIX")
         let date = dateStringFormatter.date(from: dateString)!
-        self.init(timeInterval:0, since:date)
+        self.init(timeInterval: 0, since: date)
     }
 }

--- a/Sources/Evangelium/Helpers/Enum/CustomError.swift
+++ b/Sources/Evangelium/Helpers/Enum/CustomError.swift
@@ -9,4 +9,5 @@ import Foundation
 
 enum CustomError: String, Error {
     case urlBuildError = "Error while building the URL"
+    case invalidDate = "Invalid or non existing date"
 }

--- a/Sources/Evangelium/Helpers/Enum/CustomError.swift
+++ b/Sources/Evangelium/Helpers/Enum/CustomError.swift
@@ -10,4 +10,5 @@ import Foundation
 enum CustomError: String, Error {
     case urlBuildError = "Error while building the URL"
     case invalidDate = "Invalid or non existing date"
+    case invalidReadings = "Invalid or not existing readings, check API response."
 }

--- a/Sources/Evangelium/Helpers/FileManager.swift
+++ b/Sources/Evangelium/Helpers/FileManager.swift
@@ -32,7 +32,7 @@ struct FileManager {
                     return
                 }
                 
-                let swiftyReading = ReadingFactory.create(from: readings.data, with: date)
+                let swiftyReading = try ReadingFactory.create(from: readings.data, with: date)
                 
                 let encondedData = try encoder.encode(swiftyReading)
                 try file.write(encondedData)

--- a/Sources/Evangelium/Helpers/FileManager.swift
+++ b/Sources/Evangelium/Helpers/FileManager.swift
@@ -29,6 +29,7 @@ struct FileManager {
                 
                 guard let date = readings.date else {
                     seal.reject(CustomError.invalidDate)
+                    return
                 }
                 
                 let swiftyReading = ReadingFactory.create(from: readings.data, with: date)

--- a/Sources/Evangelium/Helpers/FileManager.swift
+++ b/Sources/Evangelium/Helpers/FileManager.swift
@@ -27,28 +27,14 @@ struct FileManager {
                 
                 let file = try langFolder.createFile(named: "\(filename).json")
                 
-                if readings.data.count == 4 {
-                    let swiftyReadings = SwiftyReading(
-                        firstReading: readings.data[0],
-                        psalm: readings.data[1],
-                        secondReading: readings.data[2],
-                        gospel: readings.data[3],
-                        date: readings.date ?? "Invalid Date"
-                    )
-                    
-                    let encondedData = try encoder.encode(swiftyReadings)
-                    try file.write(encondedData)
-                } else {
-                    let swiftyReadings = SwiftyReading(
-                        firstReading: readings.data[0],
-                        psalm: readings.data[1],
-                        gospel: readings.data[2],
-                        date: readings.date ?? "Invalid Date"
-                    )
-                    
-                    let encondedData = try encoder.encode(swiftyReadings)
-                    try file.write(encondedData)
+                guard let date = readings.date else {
+                    seal.reject(CustomError.invalidDate)
                 }
+                
+                let swiftyReading = ReadingFactory.create(from: readings.data, with: date)
+                
+                let encondedData = try encoder.encode(swiftyReading)
+                try file.write(encondedData)
                 
                 seal.fulfill(())
             } catch {

--- a/Sources/Evangelium/Helpers/ReadingFactory.swift
+++ b/Sources/Evangelium/Helpers/ReadingFactory.swift
@@ -1,0 +1,52 @@
+//
+//  ReadingFactory.swift
+//  Evangelium
+//
+//  Created by Manuel Sánchez on 2/4/20.
+//
+
+import Foundation
+
+struct ReadingFactory {
+    static func create(from todayReadings: [Reading], with date: String) -> SwiftyReading{
+        let readings = todayReadings.filter { reading in reading.type == "reading" }
+        let psalm = todayReadings.filter { reading in reading.type == "psalm" }
+        let gospel = todayReadings.filter { reading in reading.type == "gospel" }
+        
+        if readings.count == 2 {
+            return SwiftyReading(
+                firstReading: readings.first,
+                psalm: !psalm.isEmpty ? psalm.first : nil,
+                secondReading: readings.last,
+                gospel: !gospel.isEmpty ? gospel.first : nil,
+                date: date
+            )
+        } else if readings.count == 1, todayReadings.first?.type == "reading"{
+            return SwiftyReading(
+                firstReading: readings.first,
+                psalm: !psalm.isEmpty ? psalm.first : nil,
+                secondReading: nil,
+                gospel: !gospel.isEmpty ? gospel.first : nil,
+                date: date
+            )
+        } else if readings.count == 1, todayReadings.first?.type != "reading"{
+            return SwiftyReading(
+                firstReading: nil,
+                psalm: !psalm.isEmpty ? psalm.first : nil,
+                secondReading: readings.first,
+                gospel: !gospel.isEmpty ? gospel.first : nil,
+                date: date
+            )
+        } else if readings.count == 0 {
+            return SwiftyReading(
+                firstReading: nil,
+                psalm: !psalm.isEmpty ? psalm.first : nil,
+                secondReading: nil,
+                gospel: !gospel.isEmpty ? gospel.first : nil,
+                date: date
+            )
+        }
+        
+        return SwiftyReading(date: "Invalid")
+    }
+}

--- a/Sources/Evangelium/Helpers/ReadingFactory.swift
+++ b/Sources/Evangelium/Helpers/ReadingFactory.swift
@@ -9,9 +9,9 @@ import Foundation
 
 enum ReadingFactory {
     static func create(from todayReadings: [Reading], with date: String) throws -> SwiftyReading {
-        let readings = todayReadings.filter { reading in reading.type == "reading" }
-        let psalm = todayReadings.filter { reading in reading.type == "psalm" }.first
-        let gospel = todayReadings.filter { reading in reading.type == "gospel" }.first
+        let readings = todayReadings.filter { reading in reading.type == .reading }
+        let psalm = todayReadings.filter { reading in reading.type == .psalm }.first
+        let gospel = todayReadings.filter { reading in reading.type == .gospel }.first
         let numberOfReadings = readings.count
         
         switch  numberOfReadings {
@@ -24,7 +24,7 @@ enum ReadingFactory {
                 date: date
             )
         case 1:
-            if readings.count == 1, todayReadings.first?.type == "reading" {
+            if readings.count == 1, todayReadings.first?.type == .some(.reading) {
                 return SwiftyReading(
                     firstReading: readings.first,
                     psalm: psalm,

--- a/Sources/Evangelium/Helpers/ReadingFactory.swift
+++ b/Sources/Evangelium/Helpers/ReadingFactory.swift
@@ -24,23 +24,13 @@ enum ReadingFactory {
                 date: date
             )
         case 1:
-            if readings.count == 1, todayReadings.first?.type == .some(.reading) {
-                return SwiftyReading(
-                    firstReading: readings.first,
-                    psalm: psalm,
-                    secondReading: nil,
-                    gospel: gospel,
-                    date: date
-                )
-            } else {
-                return SwiftyReading(
-                    firstReading: nil,
-                    psalm: psalm,
-                    secondReading: readings.first,
-                    gospel: gospel,
-                    date: date
-                )
-            }
+            return SwiftyReading(
+                firstReading: todayReadings.first?.type == .some(.reading) ? readings.first : nil,
+                psalm: psalm,
+                secondReading: todayReadings.first?.type != .some(.reading) ? readings.first : nil,
+                gospel: gospel,
+                date: date
+            )
         case 0:
             return SwiftyReading(
                 firstReading: nil,

--- a/Sources/Evangelium/Helpers/ReadingFactory.swift
+++ b/Sources/Evangelium/Helpers/ReadingFactory.swift
@@ -7,46 +7,50 @@
 
 import Foundation
 
-struct ReadingFactory {
-    static func create(from todayReadings: [Reading], with date: String) -> SwiftyReading{
+enum ReadingFactory {
+    static func create(from todayReadings: [Reading], with date: String) throws -> SwiftyReading {
         let readings = todayReadings.filter { reading in reading.type == "reading" }
-        let psalm = todayReadings.filter { reading in reading.type == "psalm" }
-        let gospel = todayReadings.filter { reading in reading.type == "gospel" }
+        let psalm = todayReadings.filter { reading in reading.type == "psalm" }.first
+        let gospel = todayReadings.filter { reading in reading.type == "gospel" }.first
+        let numberOfReadings = readings.count
         
-        if readings.count == 2 {
+        switch  numberOfReadings {
+        case 2:
             return SwiftyReading(
                 firstReading: readings.first,
-                psalm: !psalm.isEmpty ? psalm.first : nil,
+                psalm: psalm,
                 secondReading: readings.last,
-                gospel: !gospel.isEmpty ? gospel.first : nil,
+                gospel: gospel,
                 date: date
             )
-        } else if readings.count == 1, todayReadings.first?.type == "reading"{
-            return SwiftyReading(
-                firstReading: readings.first,
-                psalm: !psalm.isEmpty ? psalm.first : nil,
-                secondReading: nil,
-                gospel: !gospel.isEmpty ? gospel.first : nil,
-                date: date
-            )
-        } else if readings.count == 1, todayReadings.first?.type != "reading"{
+        case 1:
+            if readings.count == 1, todayReadings.first?.type == "reading" {
+                return SwiftyReading(
+                    firstReading: readings.first,
+                    psalm: psalm,
+                    secondReading: nil,
+                    gospel: gospel,
+                    date: date
+                )
+            } else {
+                return SwiftyReading(
+                    firstReading: nil,
+                    psalm: psalm,
+                    secondReading: readings.first,
+                    gospel: gospel,
+                    date: date
+                )
+            }
+        case 0:
             return SwiftyReading(
                 firstReading: nil,
-                psalm: !psalm.isEmpty ? psalm.first : nil,
-                secondReading: readings.first,
-                gospel: !gospel.isEmpty ? gospel.first : nil,
-                date: date
-            )
-        } else if readings.count == 0 {
-            return SwiftyReading(
-                firstReading: nil,
-                psalm: !psalm.isEmpty ? psalm.first : nil,
+                psalm: psalm,
                 secondReading: nil,
-                gospel: !gospel.isEmpty ? gospel.first : nil,
+                gospel: gospel,
                 date: date
             )
+        default:
+            throw CustomError.invalidReadings
         }
-        
-        return SwiftyReading(date: "Invalid")
     }
 }

--- a/Sources/Evangelium/Models/Reading.swift
+++ b/Sources/Evangelium/Models/Reading.swift
@@ -16,11 +16,17 @@ struct Reading: Codable {
     let title: String
     let referenceDisplayed: String
     let readingText: String
-    let type: String
+    let type: ReadingType
     
     enum CodingKeys: String, CodingKey {
         case referenceDisplayed = "reference_displayed"
         case readingText = "text"
         case title, type
     }
+}
+
+enum ReadingType: String, Codable {
+    case reading
+    case psalm
+    case gospel
 }

--- a/Sources/Evangelium/Models/SwiftyReading.swift
+++ b/Sources/Evangelium/Models/SwiftyReading.swift
@@ -8,10 +8,10 @@
 import Foundation
 
 struct SwiftyReading: Codable {
-    let firstReading: Reading
-    let psalm: Reading
+    let firstReading: Reading?
+    let psalm: Reading?
     let secondReading: Reading?
-    let gospel: Reading
+    let gospel: Reading?
     let date: String
     
     enum CodingKeys: String, CodingKey {
@@ -20,7 +20,7 @@ struct SwiftyReading: Codable {
         case psalm, gospel, date
     }
     
-    init(firstReading: Reading, psalm: Reading, secondReading: Reading? = nil, gospel: Reading, date: String) {
+    init(firstReading: Reading? = nil, psalm: Reading? = nil, secondReading: Reading? = nil, gospel: Reading? = nil, date: String) {
         self.firstReading = firstReading
         self.psalm = psalm
         self.secondReading = secondReading

--- a/Sources/Evangelium/Models/SwiftyReading.swift
+++ b/Sources/Evangelium/Models/SwiftyReading.swift
@@ -19,12 +19,4 @@ struct SwiftyReading: Codable {
         case secondReading = "second_reading"
         case psalm, gospel, date
     }
-    
-    init(firstReading: Reading? = nil, psalm: Reading? = nil, secondReading: Reading? = nil, gospel: Reading? = nil, date: String) {
-        self.firstReading = firstReading
-        self.psalm = psalm
-        self.secondReading = secondReading
-        self.gospel = gospel
-        self.date = date
-    }
 }


### PR DESCRIPTION
**To give context of the problem:**

There's a case when in a date and language, the origin API will provide less readings than expected, and the past solution was tied to specific number of readings so crashed when less where provided.

**The solution:**

Create a factory that delivers objects ready to be procesed by the file manager, based on the number and type of readings passed.

**Important to know:**

As of now the API endpoint is being injected by the CI, for further testing can provide it in private, or in case advice is code quality wise, it can be threaded in here in the review comments.